### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,18 +103,18 @@ This may be a good time to change the SSH password on the device to a more secur
 
 Build and install the KVM software in the SSH session:
 
-```
+```shell
+sudo apt update
+sudo apt install -y git janus janus-dev cmake g++ libglib2.0-dev
+sudo systemctl disable janus
+
 cd ~
 git clone https://github.com/catid/kvm.git
 cd kvm
 
-sudo apt install janus janus-dev cmake g++ libglib2.0-dev
-
-sudo systemctl disable janus
-
 mkdir build
 cd build
-cmake ..
+cmake ../..
 make -j4
 
 cd /home/pi/kvm/scripts/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cd kvm
 
 mkdir build
 cd build
-cmake ../..
+cmake ../
 make -j4
 
 cd /home/pi/kvm/scripts/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cd kvm
 
 mkdir build
 cd build
-cmake ../
+cmake ..
 make -j4
 
 cd /home/pi/kvm/scripts/


### PR DESCRIPTION
Fix a few issues with the install instructions:
* git is not available by default on a fresh Raspberry Pi OS install
* The user should probably apt update before installing
* To make the commands, copy/pasteable, I added a -y to apt install
* Fixed the relative path for cmake